### PR TITLE
Change search result links behavior: now click to play

### DIFF
--- a/public/js/peerflix-web.js
+++ b/public/js/peerflix-web.js
@@ -103,13 +103,19 @@ $(document).ready(function() {
         var torrentLink = result.torrentLink;
         var seeds = result.seeds;
         var leechs = result.leechs;
-        $('#torrent-table').append('<tr><td style="word-break: break-all;"><a href="' + torrentLink + '">' + title + '</a></td><td style="text-align: center;"><span style="color:#00CB95;">' + seeds + '</span></td><td style="text-align: center;"><span style="color:#FF646C;">' + leechs + '</span></td></tr>');
+        $('#torrent-table').append('<tr><td style="word-break: break-all;"><a class="torrent-link" href="' + torrentLink + '">' + title + '</a></td><td style="text-align: center;"><span style="color:#00CB95;">' + seeds + '</span></td><td style="text-align: center;"><span style="color:#FF646C;">' + leechs + '</span></td></tr>');
       });
       if (!searchResults.length) { $('#torrent-table').empty(); }
     })
     .fail(function() {
       $('#torrent-table').empty();
     });
+  });
+
+  $('#torrent-table').on('click', '.torrent-link', function(e) {
+    e.preventDefault();
+    $('#torrent-url').val( $(this).attr('href') );
+    $('#start').click();
   });
 
   $('#torrent-query').keydown(function(e) {


### PR DESCRIPTION
Hey, thanks for the app :)

I was a bit annoyed by the current behavior of the search results. When clicking on a link I was redirected to a webpage to download the torrent file. I changed this so that clicking on a link would directly play the video.

What do you think?
