### PR TITLE
Matching subtitles auto download

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ $ npm install
 $ node server
 ```
 
+###Server options
+
+You can pass several options when starting the server. You can check what's available through the `node server --help` command. Mostly, it allows you to have subtitles automatically downloaded thanks to [subliminal](https://github.com/Diaoul/subliminal).
+
 **Running on startup**
 
 This project can be setup to run from /etc/init.d so it will automatically start up with your Raspberry Pi. Edit the custom configs at the top of the `example.peerflix-web` file and rename and move the script to `/etc/init.d/peerflix-web`. Once in the init.d directory, you can control the server using the following commands:
@@ -44,6 +48,7 @@ Currently this project is designed specifically to work with omxplayer running o
 * `node`
 * `npm`
 * `omxplayer` - default media player for raspbian
+* [`subliminal`](https://github.com/Diaoul/subliminal) when using the `--subtitles` option.
 
 ##License
 MIT

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "hapi": "^8.4.0",
     "ip": "^0.3.2",
     "kickass-torrent": "akinsey/node-kickass-torrent",
+    "minimist": "^1.1.2",
     "mkdirp": "^0.5.0",
     "node-ip": "^0.1.0",
     "node-uuid": "^1.4.1",
@@ -42,7 +43,7 @@
     "read-torrent": "^1.0.0",
     "rimraf": "^2.3.2"
   },
-  "bin" : {
-    "peerflix-web" : "./server.js"
+  "bin": {
+    "peerflix-web": "./server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -16,9 +16,10 @@ var fs = require('fs');
 var kickass = require('kickass-torrent');
 var peerflix = require('peerflix');
 var omx = require('omxctrl');
+var serverArgs = require('minimist')(process.argv.slice(2));
 
 // Configs
-var PORT = process.env.PORT || process.argv[2] || 8080;
+var PORT = process.env.PORT || serverArgs.port || 8080;
 var LOG_ENABLED = true;
 
 // Params

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ var cliArguments = require('minimist')(process.argv.slice(2));
 
 // Configs
 var PORT = process.env.PORT || cliArguments.port || 8080;
-var LOG_ENABLED = true;
+var LOG_ENABLED = cliArguments.verbose !== undefined ? !!cliArguments.verbose : true;
 var USE_SUBTITLES = !!cliArguments.subtitles;
 
 // Params

--- a/server.js
+++ b/server.js
@@ -19,6 +19,22 @@ var omx = require('omxctrl');
 var execSync = require('child_process').execSync;
 var cliArguments = require('minimist')(process.argv.slice(2));
 
+if (cliArguments.help) {
+  console.log([
+    'You can pass several options to the server command:',
+    '  --help: this message',
+    '  --port: the port to use for the server (defaults to 8080)',
+    '  --verbose: show the server log (defaults to true)',
+    '  --subtitles: when selecting a torrent to watch, try to download matching subtitles',
+    '    with `subliminal` python program (defaults to false)',
+    '  --subliminal_bin: `subliminal` path/executable (defaults to \'subliminal\')',
+    '  --subliminal_args: arguments to pass to the `subliminal download` command (-s option is forced)',
+    '',
+    '  Example:',
+    '    node server --port 8081 --subtitles --subliminal_args="-l fr"'
+  ].join('\n'));
+  process.exit(0);
+}
 // Configs
 var PORT = process.env.PORT || cliArguments.port || 8080;
 var LOG_ENABLED = cliArguments.verbose !== undefined ? !!cliArguments.verbose : true;
@@ -62,11 +78,11 @@ var clearTorrentCache = function() {
 /**
  * download the best subtitles file possible through subliminal for the given torrent
  *
- * note: the subliminal -s and -v options are forced
+ * note: the subliminal -s is forced
  */
 var subtitles = function(torrent) {
   var bin = cliArguments.subliminal_bin || 'subliminal';
-  var options = '-s -v ' + (cliArguments.subliminal_args || '');
+  var options = '-s ' + (cliArguments.subliminal_args || '');
   var subliminalCommand = [bin, 'download', options, torrent.name].join(' ');
   var subliminalOutput;
   try {


### PR DESCRIPTION
Hey,

This is my attempt at getting subtitles automatically when playing videos. It uses [subliminal](https://github.com/Diaoul/subliminal) under the hood so it is required on the machine (`sudo pip install subliminal`).

Start the server with a 'subtitles' option and optional 'subliminal_args' to see if it works.
Since we can now pass options to the server command, I added the "port" and "verbose" options.

I didn't bother making any UI since I want to use subtitles _all the time_, it was more straightforward to just have a cli option. But this can definitely be a starting point for you if you want to make some UI :)

:warning: I actually can't figure out why but my attempts at making peerflix-web work on my own raspberry pi all failed (even on the master branch). When trying to play a torrent, the raspberry stays at 100% cpu for a couple of minutes before going back to normal but does nothing at all. The `peerflix` command on its own works great though.
So anyway, be sure to test this yourself since I couldn't :P
